### PR TITLE
fix url to blog post

### DIFF
--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -61,7 +61,7 @@ const Home = (): React.ReactElement => (
     <div className={clsx(styles.text, styles.preview)}>
       In the meantime, check out{' '}
       <ExternalLink
-        href="https://foobar.agency/blog/software-engineering/An-analogy-on-JavaScript%E2%80%99s-single-threaded-asynchronicity"
+        href="https://foobar.agency/blog/software-engineering/An-analogy-of-JavaScript%E2%80%99s-single-threaded-asynchronicity"
         noA11yIcon
       >
         one of my previously written posts

--- a/src/pages/home/test.tsx
+++ b/src/pages/home/test.tsx
@@ -23,6 +23,6 @@ it('renders link to external blog post', () => {
   expect(externalBlogPostLink).toBeInTheDocument();
   expect(externalBlogPostLink).toHaveAttribute(
     'href',
-    'https://foobar.agency/blog/software-engineering/An-analogy-on-JavaScript%E2%80%99s-single-threaded-asynchronicity'
+    'https://foobar.agency/blog/software-engineering/An-analogy-of-JavaScript%E2%80%99s-single-threaded-asynchronicity'
   );
 });


### PR DESCRIPTION
The URL to the blog post changed from foobar's side. This PR updates the url to point to the current one.