### PR TITLE
Add callout block

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
   "css.customData": [".vscode/postcss.css-data.json"],
-  "cSpell.words": ["clsx"]
+  "cSpell.words": ["callout", "clsx"]
 }

--- a/src/components/callout-block/callout-block.tsx
+++ b/src/components/callout-block/callout-block.tsx
@@ -1,0 +1,9 @@
+import clsx from 'clsx';
+import styles from './styles.module.css';
+import type { CalloutBlockProps } from './types';
+
+const CalloutBlock = ({ className, ...otherProps }: CalloutBlockProps) => (
+  <figure {...otherProps} className={clsx(className, styles.calloutBlock)} />
+);
+
+export default CalloutBlock;

--- a/src/components/callout-block/index.ts
+++ b/src/components/callout-block/index.ts
@@ -1,0 +1,1 @@
+export { default } from './callout-block';

--- a/src/components/callout-block/styles.module.css
+++ b/src/components/callout-block/styles.module.css
@@ -1,0 +1,9 @@
+.calloutBlock {
+  display: flex;
+  gap: var(--spacing-s);
+  align-items: flex-start;
+  padding: var(--spacing-s);
+  margin: var(--spacing-s) 0;
+  background: var(--color-neutral-border);
+  border-radius: var(--spacing-xs);
+}

--- a/src/components/callout-block/styles.module.css.d.ts
+++ b/src/components/callout-block/styles.module.css.d.ts
@@ -1,0 +1,4 @@
+declare const styles: {
+  readonly calloutBlock: string;
+};
+export = styles;

--- a/src/components/callout-block/test.tsx
+++ b/src/components/callout-block/test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import CalloutBlock from './callout-block';
+
+it('renders "figure" landmark', () => {
+  render(<CalloutBlock>some children</CalloutBlock>);
+
+  expect(screen.getByRole('figure')).toBeInTheDocument();
+});
+
+it('renders children', () => {
+  render(
+    <CalloutBlock>
+      <p>children 1</p>
+      <div>children 2</div>
+    </CalloutBlock>
+  );
+
+  expect(screen.getByText('children 1')).toBeInTheDocument();
+  expect(screen.getByText('children 2')).toBeInTheDocument();
+});

--- a/src/components/callout-block/types.ts
+++ b/src/components/callout-block/types.ts
@@ -1,0 +1,5 @@
+type CalloutBlockProps = React.ComponentPropsWithoutRef<'figure'> & {
+  children: React.ReactNode;
+};
+
+export type { CalloutBlockProps };


### PR DESCRIPTION
These changes add the callout block. This component is meant to be used in the blog section of the site. The component looks like this:
<img width="831" alt="image" src="https://github.com/segebre-dev/segebre-dev/assets/10774915/f031878a-ed88-4b74-a49d-aaaefd88dc94">
