### PR TITLE
Add a 404 page

### DIFF
--- a/project-structure.yml
+++ b/project-structure.yml
@@ -8,19 +8,32 @@ structure:
         - name: 'components'
         - name: 'utils'
         - name: 'app'
-          ruleId: 'appFolder' # we need to recursively check all the sub-folders of the `app` folder
+          children:
+            - name: 'not-found' # we accept the `not-found.ts` file
+              extension: 'ts'
+            - name: '_not-found'
+              ruleId: noPathAllowed # We want to make sure no `page` or `layout` files exist under the `_not-found` folder
+            - ruleId: 'pageAndLayout'
+            - ruleId: 'pageAndLayoutFolders'
+            - ruleId: 'subPaths'
         - name: 'mdx-components'
         - name: 'types.d'
           extension: 'ts'
 rules:
-  appFolder:
+  appFolder: # We use this appFolder for recursion. It is different than the root /app folder due to files like `not-found`
     children:
-      - name: /^(?:page|layout)$/ # we only want to accept the `page` and `layout` files
-        extension: '.ts'
-      - name: /^_(?:page|layout)$/ # we want all the `page` and `layout` assets to exist under the respective folders `_page` and `_layout`
-        ruleId: noPathAllowed # We want to make sure no `page` or `layout` files exist under the `_page` and `_layout` folders
-      - name: /^[^_]/ # we support any folder that does not start with an `_` to allow the creation of further paths
-        ruleId: 'appFolder' # we recursively apply these rules to all sub-folders
+      - ruleId: 'pageAndLayout'
+      - ruleId: 'pageAndLayoutFolders'
+      - ruleId: 'subPaths'
+  pageAndLayout:
+    name: /^(?:page|layout)$/ # we only want to accept the `page` and `layout` files
+    extension: '.ts'
+  pageAndLayoutFolders:
+    name: /^_(?:page|layout)$/ # we want all the `page` and `layout` assets to exist under the respective folders `_page` and `_layout`
+    ruleId: noPathAllowed # We want to make sure no `page` or `layout` files exist under the `_page` and `_layout` folders
+  subPaths:
+    name: /^[^_]/ # we support any folder that does not start with an `_` to allow the creation of further paths
+    ruleId: 'appFolder' # we recursively apply these rules to all sub-folders
   noPathAllowed:
     children:
       - name: /^(?!layout$|page$)${{kebab-case}}/ # we allow anything that does not create a new path

--- a/src/app/_layout/global.css
+++ b/src/app/_layout/global.css
@@ -41,6 +41,8 @@ h6 {
   overflow-wrap: break-word;
 }
 
+/* End of CSS reset */
+
 /* Design system */
 html {
   /* Colors */

--- a/src/app/_layout/global.css
+++ b/src/app/_layout/global.css
@@ -117,4 +117,16 @@ html {
   h3 {
     font: var(--font-heading-3);
   }
+
+  a {
+    color: var(--color-primary-base);
+
+    &:hover {
+      color: var(--color-primary-hover);
+    }
+
+    &:active {
+      color: var(--color-primary-active);
+    }
+  }
 }

--- a/src/app/_not-found/index.ts
+++ b/src/app/_not-found/index.ts
@@ -1,0 +1,1 @@
+export { default } from './not-found';

--- a/src/app/_not-found/not-found.tsx
+++ b/src/app/_not-found/not-found.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link';
+import styles from './styles.module.css';
+
+const NotFoundPage = () => (
+  <>
+    <h1 className={styles.heading}>Not found</h1>
+    <p className={styles.message}>
+      Oops! The page is playing hide and seek in cyberspace. 👾 I'm already on
+      the case! 🧑‍🚀 <br />
+      In the meantime, feel free to <Link href="/blog">explore the blog</Link>.
+      🚀
+    </p>
+    <Link href="/" className={styles.goHomeLink}>
+      Go home →
+    </Link>
+  </>
+);
+
+export default NotFoundPage;

--- a/src/app/_not-found/styles.module.css
+++ b/src/app/_not-found/styles.module.css
@@ -1,0 +1,13 @@
+.heading {
+  margin-top: var(--spacing-3xl);
+  text-transform: uppercase;
+}
+
+.message {
+  margin-top: var(--spacing-s);
+  text-align: center;
+}
+
+.goHomeLink {
+  margin-top: var(--spacing-l);
+}

--- a/src/app/_not-found/styles.module.css.d.ts
+++ b/src/app/_not-found/styles.module.css.d.ts
@@ -1,0 +1,6 @@
+declare const styles: {
+  readonly goHomeLink: string;
+  readonly heading: string;
+  readonly message: string;
+};
+export = styles;

--- a/src/app/_not-found/test.tsx
+++ b/src/app/_not-found/test.tsx
@@ -1,0 +1,32 @@
+import { screen, render } from '@testing-library/react';
+import NotFoundPage from '.';
+
+it('renders the not found header', () => {
+  render(<NotFoundPage />);
+
+  expect(
+    screen.getByRole('heading', { level: 1, name: /not found/i })
+  ).toBeInTheDocument();
+});
+
+it('renders the not found description', () => {
+  render(<NotFoundPage />);
+
+  expect(screen.getByText(/Oops!.*hide and seek/)).toBeInTheDocument();
+});
+
+it('renders a link to the blog', () => {
+  render(<NotFoundPage />);
+
+  const linkToBlog = screen.getByRole('link', { name: 'explore the blog' });
+  expect(linkToBlog).toBeInTheDocument();
+  expect(linkToBlog).toHaveAttribute('href', '/blog');
+});
+
+it('renders a link to go home', () => {
+  render(<NotFoundPage />);
+
+  const linkToHomePage = screen.getByRole('link', { name: /go home/i });
+  expect(linkToHomePage).toBeInTheDocument();
+  expect(linkToHomePage).toHaveAttribute('href', '/');
+});

--- a/src/app/not-found.ts
+++ b/src/app/not-found.ts
@@ -1,0 +1,1 @@
+export { default } from './_not-found';

--- a/src/mdx-components/index.tsx
+++ b/src/mdx-components/index.tsx
@@ -10,11 +10,7 @@ const styledA = ({
   className,
   ...otherProps
 }: React.ComponentPropsWithoutRef<'a'>) => (
-  <ExternalLink
-    href={href}
-    className={clsx(className, styles.link)}
-    {...otherProps}
-  >
+  <ExternalLink href={href} className={className} {...otherProps}>
     {children}
   </ExternalLink>
 );

--- a/src/mdx-components/styles.module.css
+++ b/src/mdx-components/styles.module.css
@@ -1,15 +1,3 @@
-.link {
-  color: var(--color-primary-base);
-
-  &:hover {
-    color: var(--color-primary-hover);
-  }
-
-  &:active {
-    color: var(--color-primary-active);
-  }
-}
-
 .heading {
   margin-top: var(--spacing-m);
 }

--- a/src/mdx-components/styles.module.css.d.ts
+++ b/src/mdx-components/styles.module.css.d.ts
@@ -1,7 +1,6 @@
 declare const styles: {
   readonly blockquote: string;
   readonly heading: string;
-  readonly link: string;
   readonly paragraph: string;
 };
 export = styles;


### PR DESCRIPTION
These changes:
- add a 404 page,
- update the project structure to support the `not-found` root page,
- define default styles for links, and
- remove duplicate specific style for the MDX link components.