### PR TITLE
add missing peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "jest": "29.7.0",
     "jest-environment-jsdom": "29.7.0",
     "lint-staged": "15.2.0",
+    "postcss": "8.4.34",
     "postcss-flexbugs-fixes": "5.0.2",
     "postcss-nesting": "12.0.1",
     "postcss-preset-env": "9.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6759,6 +6759,15 @@ postcss@8.4.31:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
+postcss@8.4.34:
+  version "8.4.34"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.34.tgz#563276e86b4ff20dfa5eed0d394d4c53853b2051"
+  integrity sha512-4eLTO36woPSocqZ1zIrFD2K1v6wH7pY1uBh0JIM2KKfrVtGvPFiAku6aNOP0W1Wr9qwnaCsF0Z+CrVnryB2A8Q==
+  dependencies:
+    nanoid "^3.3.7"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
+
 postcss@^8.0.0, postcss@^8.4.32:
   version "8.4.32"
   resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz"


### PR DESCRIPTION
These changes add a missing peer dependency and thus removes the warnings when installing the packages.