### PR TITLE
fix generic 404 Page

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
These changes aim to fix the generic 404 Not Found page currently showing when deploying to Vercel. These changes are based on the post from [Stanlisberg](https://dev.to/stanlisberg) on [Resolving the Vercel 404 "Page Not Found" Error After Page Refresh.](https://dev.to/stanlisberg/resolving-the-vercel-404-page-not-found-error-after-page-refresh-9b9).

<img width="444" alt="image" src="https://github.com/segebre-dev/segebre-dev/assets/10774915/f1361c5e-6e71-44a7-94ae-cb10507dcae9">
