### PR TITLE
Implement divider using html

### DIFF
--- a/src/app/_layout/navigation-breadcrumbs/navigation-breadcrumbs.tsx
+++ b/src/app/_layout/navigation-breadcrumbs/navigation-breadcrumbs.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { Fragment } from 'react';
 import styles from './styles.module.css';
 import useNavigationLinks, { NavigationLink } from './use-navigation-links';
 
@@ -17,9 +18,12 @@ const NavigationBreadcrumbs = () => {
     <nav aria-label="breadcrumbs" className={styles.container}>
       <ol>
         {navigationLinks.map(({ name, path }) => (
-          <li key={path}>
-            <Link href={path}>{name}</Link>
-          </li>
+          <Fragment key={path}>
+            <li>
+              <Link href={path}>{name}</Link>
+            </li>
+            <span aria-hidden="true"> / </span>
+          </Fragment>
         ))}
         <li aria-current="page">{currentPage.name}</li>
       </ol>

--- a/src/app/_layout/navigation-breadcrumbs/styles.module.css
+++ b/src/app/_layout/navigation-breadcrumbs/styles.module.css
@@ -7,11 +7,6 @@
 
     li {
       display: inline-block;
-
-      & + &::before {
-        padding: 0 var(--spacing-xs);
-        content: '/' / '';
-      }
     }
   }
 }

--- a/src/app/_layout/navigation-breadcrumbs/test.tsx
+++ b/src/app/_layout/navigation-breadcrumbs/test.tsx
@@ -4,17 +4,53 @@ import NavigationBreadcrumbs from '.';
 
 jest.mock('./use-navigation-links');
 
-it('renders the navigation breadcrumbs when NOT in the root page', () => {
-  jest.spyOn(useNavigationLinksFile, 'default').mockReturnValueOnce([
-    { name: 'home', path: '/' },
-    { name: 'blog', path: '/blog' },
-  ]);
+describe('when NOT in the root page', () => {
+  it('renders the navigation breadcrumbs', () => {
+    jest.spyOn(useNavigationLinksFile, 'default').mockReturnValueOnce([
+      { name: 'home', path: '/' },
+      { name: 'blog', path: '/blog' },
+    ]);
 
-  render(<NavigationBreadcrumbs />);
+    render(<NavigationBreadcrumbs />);
 
-  expect(
-    screen.getByRole('navigation', { name: 'breadcrumbs' })
-  ).toBeInTheDocument();
+    expect(
+      screen.getByRole('navigation', { name: 'breadcrumbs' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders the decorative navigation breadcrumbs divider between elements', () => {
+    jest.spyOn(useNavigationLinksFile, 'default').mockReturnValueOnce([
+      { name: 'home', path: '/' },
+      { name: 'blog', path: '/blog' },
+      { name: 'post', path: '/blog/post' },
+    ]);
+
+    render(<NavigationBreadcrumbs />);
+
+    const dividers = screen.getAllByText('/');
+    dividers.forEach((divider) => {
+      expect(divider).toBeInTheDocument();
+      expect(divider).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+
+  it('renders a link to each of the parent pages', () => {
+    jest.spyOn(useNavigationLinksFile, 'default').mockReturnValueOnce([
+      { name: 'home', path: '/' },
+      { name: 'blog', path: '/blog' },
+      { name: 'first-post', path: '/blog/first-post' },
+    ]);
+
+    render(<NavigationBreadcrumbs />);
+
+    const homeLink = screen.getByRole('link', { name: 'home' });
+    expect(homeLink).toBeInTheDocument();
+    expect(homeLink).toHaveAttribute('href', '/');
+
+    const blogLink = screen.getByRole('link', { name: 'blog' });
+    expect(blogLink).toBeInTheDocument();
+    expect(blogLink).toHaveAttribute('href', '/blog');
+  });
 });
 
 it('does NOT renders the navigation breadcrumbs when in the root page', () => {
@@ -27,24 +63,6 @@ it('does NOT renders the navigation breadcrumbs when in the root page', () => {
   expect(
     screen.queryByRole('navigation', { name: 'breadcrumbs' })
   ).not.toBeInTheDocument();
-});
-
-it('renders a link to each of the parent pages', () => {
-  jest.spyOn(useNavigationLinksFile, 'default').mockReturnValueOnce([
-    { name: 'home', path: '/' },
-    { name: 'blog', path: '/blog' },
-    { name: 'first-post', path: '/blog/first-post' },
-  ]);
-
-  render(<NavigationBreadcrumbs />);
-
-  const homeLink = screen.getByRole('link', { name: 'home' });
-  expect(homeLink).toBeInTheDocument();
-  expect(homeLink).toHaveAttribute('href', '/');
-
-  const blogLink = screen.getByRole('link', { name: 'blog' });
-  expect(blogLink).toBeInTheDocument();
-  expect(blogLink).toHaveAttribute('href', '/blog');
 });
 
 it('renders the current page but not as a link', () => {


### PR DESCRIPTION
These changes replace the previous implementation that was using CSS pseudoelements due to the lack of support for the [alternative text on CSS pseudoelement content](https://developer.mozilla.org/en-US/docs/Web/CSS/content#alternative_text). The new changes use HTML and avoid the divider to be read by screen readers by using `aria-hidden`.

I also researched this [alternative suggestion](https://www.w3.org/WAI/content-assets/wai-aria-practices/patterns/breadcrumb/examples/css/breadcrumb.css) but the design was ultimately not as nice since the `/` was above the underline and did not look as good.
```css
/* Extracted from source as reference in case source link breaks */
nav.breadcrumb li + li::before {
  display: inline-block;
  margin: 0 0.25em;
  transform: rotate(15deg);
  border-right: 0.1em solid currentcolor;
  height: 0.8em;
  content: "";
}
```