### PR TITLE
Add privacy policy

### DIFF
--- a/project-structure.yml
+++ b/project-structure.yml
@@ -30,7 +30,7 @@ rules:
     name: /^(?:page|layout)$/ # we only want to accept the `page` and `layout` files
     extension: '.ts'
   pageAndLayoutFolders:
-    name: /^_(?:page|layout)$/ # we want all the `page` and `layout` assets to exist under the respective folders `_page` and `_layout`
+    name: /^_(?:page|layout|shared)$/ # we want all the `page` and `layout` assets to exist under the respective folders `_page` and `_layout`
     ruleId: noPathAllowed # We want to make sure no `page` or `layout` files exist under the `_page` and `_layout` folders
   subPaths:
     name: /^(?!_)\(?${{kebab-case}}\)?$/ # we support any folder that does not start with an `_` to allow the creation of further paths

--- a/src/app/(legal)/_shared/styles.module.css
+++ b/src/app/(legal)/_shared/styles.module.css
@@ -1,0 +1,4 @@
+.header2 {
+  margin-top: var(--spacing-m);
+  margin-bottom: var(--spacing-xs);
+}

--- a/src/app/(legal)/_shared/styles.module.css.d.ts
+++ b/src/app/(legal)/_shared/styles.module.css.d.ts
@@ -1,4 +1,4 @@
 declare const styles: {
-  readonly contactDefinitionList: string;
+  readonly header2: string;
 };
 export = styles;

--- a/src/app/(legal)/imprint/_page/index.tsx
+++ b/src/app/(legal)/imprint/_page/index.tsx
@@ -1,9 +1,10 @@
+import sharedStyles from '../../_shared/styles.module.css';
 import styles from './styles.module.css';
 
 const Imprint = () => (
   <>
     <h1>Imprint</h1>
-    <h2 className={styles.categoryTitle}>
+    <h2 className={sharedStyles.header2}>
       Information in accordance with § 5 TMG
     </h2>
     <p lang="de">
@@ -17,7 +18,7 @@ const Imprint = () => (
       <br />
       Deutschland
     </p>
-    <h2 className={styles.categoryTitle}>Contact Information</h2>
+    <h2 className={sharedStyles.header2}>Contact Information</h2>
     <dl className={styles.contactDefinitionList}>
       <div>
         <dt>Email:</dt>
@@ -36,7 +37,7 @@ const Imprint = () => (
         </dd>
       </div>
     </dl>
-    <h2 className={styles.categoryTitle}>
+    <h2 className={sharedStyles.header2}>
       Responsible for content according to § 55 II RStV
     </h2>
     <p lang="de">
@@ -50,7 +51,7 @@ const Imprint = () => (
       <br />
       Deutschland
     </p>
-    <h2 className={styles.categoryTitle}>Disclaimer</h2>
+    <h2 className={sharedStyles.header2}>Disclaimer</h2>
     <p>
       The content on this website is for informational purposes only. While
       efforts are made to ensure the accuracy of the information, no guarantee

--- a/src/app/(legal)/imprint/_page/styles.module.css
+++ b/src/app/(legal)/imprint/_page/styles.module.css
@@ -1,8 +1,3 @@
-.categoryTitle {
-  margin-top: var(--spacing-m);
-  margin-bottom: var(--spacing-xs);
-}
-
 .contactDefinitionList {
   dt,
   dd {

--- a/src/app/(legal)/privacy/_page/index.tsx
+++ b/src/app/(legal)/privacy/_page/index.tsx
@@ -45,11 +45,11 @@ const PrivacyPage = () => (
     </p>
     <h2 className={sharedStyles.header2}>Changes to This Policy</h2>
     <p>
-      We may update this privacy policy from time to time. Changes will be
-      posted on this page.
+      We may update this privacy policy from time to time. The up-to-date
+      version will continue to be available on this page.
     </p>
     <h2 className={sharedStyles.header2}>Effective Date</h2>
-    <p>This policy is effective as of 2024-06-02.</p>
+    <p>This policy is effective as of 2024-06-22.</p>
   </>
 );
 

--- a/src/app/(legal)/privacy/_page/index.tsx
+++ b/src/app/(legal)/privacy/_page/index.tsx
@@ -53,4 +53,5 @@ const PrivacyPage = () => (
   </>
 );
 
+export { metadata } from './metadata';
 export default PrivacyPage;

--- a/src/app/(legal)/privacy/_page/index.tsx
+++ b/src/app/(legal)/privacy/_page/index.tsx
@@ -1,0 +1,56 @@
+import ExternalLink from '@/components/external-link';
+import sharedStyles from '../../_shared/styles.module.css';
+
+const PrivacyPage = () => (
+  <>
+    <h1>Privacy Policy</h1>
+    <h2 className={sharedStyles.header2}>Introduction</h2>
+    <p>
+      Segebre.dev respects your privacy and is committed to protecting your
+      personal data. This privacy policy explains how we handle your
+      information.
+    </p>
+    <h2 className={sharedStyles.header2}>Data Collection</h2>
+    <p>
+      Segebre.dev does not collect any personal data, use cookies, nor track
+      visitors. No personal data is shared with third parties.
+    </p>
+    <h2 className={sharedStyles.header2}>Hosting and Analytics</h2>
+    <p>
+      Segebre.dev is hosted on Vercel. Vercel may collect anonymized data for
+      analytics purposes. You can{' '}
+      <ExternalLink href="https://vercel.com/docs/analytics/privacy-policy">
+        find more information on how Vercel handles privacy and compliance
+        directly on their website
+      </ExternalLink>
+      .
+    </p>
+    <h2 className={sharedStyles.header2}>External Links</h2>
+    <p>
+      Our website may contain links to other sites. We are not responsible for
+      their content nor privacy practices.
+    </p>
+    <h2 className={sharedStyles.header2}>Contact Information</h2>
+    <p>
+      If you have any concerns or questions about this privacy policy, please{' '}
+      <a href="mailto:privacy@segebre.dev">contact us at privacy@segebre.dev</a>
+      .
+    </p>
+    <h2 className={sharedStyles.header2}>Your Rights</h2>
+    <p>
+      Under various privacy laws, including GDPR, CCPA, CPRA, CalOPPA, PIPEDA,
+      and Australia's Privacy Act, you have the right to access, correct, or
+      delete any personal information we might hold about you. Since we do not
+      collect any data, these rights are not applicable.
+    </p>
+    <h2 className={sharedStyles.header2}>Changes to This Policy</h2>
+    <p>
+      We may update this privacy policy from time to time. Changes will be
+      posted on this page.
+    </p>
+    <h2 className={sharedStyles.header2}>Effective Date</h2>
+    <p>This policy is effective as of 2024-06-02.</p>
+  </>
+);
+
+export default PrivacyPage;

--- a/src/app/(legal)/privacy/_page/index.tsx
+++ b/src/app/(legal)/privacy/_page/index.tsx
@@ -3,7 +3,7 @@ import sharedStyles from '../../_shared/styles.module.css';
 
 const PrivacyPage = () => (
   <>
-    <h1>Privacy Policy</h1>
+    <h1>Privacy policy</h1>
     <h2 className={sharedStyles.header2}>Introduction</h2>
     <p>
       Segebre.dev respects your privacy and is committed to protecting your

--- a/src/app/(legal)/privacy/_page/metadata.ts
+++ b/src/app/(legal)/privacy/_page/metadata.ts
@@ -1,0 +1,7 @@
+import { Metadata } from 'next';
+
+const metadata: Metadata = {
+  title: 'Privacy policy',
+};
+
+export { metadata };

--- a/src/app/(legal)/privacy/page.ts
+++ b/src/app/(legal)/privacy/page.ts
@@ -1,1 +1,1 @@
-export { default } from './_page';
+export { default, metadata } from './_page';

--- a/src/app/(legal)/privacy/page.ts
+++ b/src/app/(legal)/privacy/page.ts
@@ -1,0 +1,1 @@
+export { default } from './_page';

--- a/src/app/_layout/footer/footer.tsx
+++ b/src/app/_layout/footer/footer.tsx
@@ -21,7 +21,7 @@ const Footer = () => {
         <p>Developed by</p>
         <p>Juan Enrique Segebre Zaghmout</p>
       </div>
-      <div>
+      <div className={styles.legalLinksContainer}>
         <Link href="/imprint">Imprint</Link>
       </div>
       <div className={styles.text}>

--- a/src/app/_layout/footer/footer.tsx
+++ b/src/app/_layout/footer/footer.tsx
@@ -23,6 +23,7 @@ const Footer = () => {
       </div>
       <div className={styles.legalLinksContainer}>
         <Link href="/imprint">Imprint</Link>
+        <Link href="/privacy">Privacy policy</Link>
       </div>
       <div className={styles.text}>
         © 2021 Juan Enrique Segebre Zaghmout. All rights reserved.

--- a/src/app/_layout/footer/styles.module.css
+++ b/src/app/_layout/footer/styles.module.css
@@ -29,3 +29,15 @@
     }
   }
 }
+
+.legalLinksContainer {
+  composes: text;
+
+  & > a {
+    & + & {
+      padding-left: var(--spacing-xs);
+      margin-left: var(--spacing-xs);
+      border-left: 1px solid var(--color-neutral-text);
+    }
+  }
+}

--- a/src/app/_layout/footer/styles.module.css.d.ts
+++ b/src/app/_layout/footer/styles.module.css.d.ts
@@ -1,6 +1,7 @@
 declare const styles: {
   readonly authorMessageContainer: string;
   readonly container: string;
+  readonly legalLinksContainer: string;
   readonly socialsContainer: string;
   readonly text: string;
 };

--- a/src/app/_layout/footer/test.tsx
+++ b/src/app/_layout/footer/test.tsx
@@ -54,3 +54,11 @@ it('renders the imprint', () => {
   expect(githubLink).toBeInTheDocument();
   expect(githubLink).toHaveAttribute('href', '/imprint');
 });
+
+it('renders the privacy policy', () => {
+  render(<Footer />);
+
+  const githubLink = screen.getByRole('link', { name: /Privacy policy/ });
+  expect(githubLink).toBeInTheDocument();
+  expect(githubLink).toHaveAttribute('href', '/privacy');
+});


### PR DESCRIPTION
These changes add the privacy policy page. To get there, a link was added to the footer; furthermore, the footer styles where updated to include the legal links.

We also added the ability to have a `_shared` folder where we can place reused styles and components.